### PR TITLE
Make it work in Node 4.x.y by adding 'use strict'

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,7 @@
 //#!/usr/bin/env node
 
+'use strict';
+
 const clang_tools_bin_dir = require('./')
 const path = require('path')
 const proc = require('child_process')


### PR DESCRIPTION
Node 4 fails to run code with ES6 stuff (such as `let`, `const`) if `'use strict';` is not placed at the top of the file.